### PR TITLE
Helper Methods, OAuth1 Support

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,12 +5,11 @@ use Laravel\Socialite\SocialiteServiceProvider;
 
 class ServiceProvider extends SocialiteServiceProvider
 {
-
     /**
      * {@inheritdoc}
      */
     public function boot()
     {
-        \Event::fire(new SocialiteWasCalled());
+        event(new SocialiteWasCalled());
     }
 }

--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -4,16 +4,30 @@ namespace SocialiteProviders\Manager;
 class SocialiteWasCalled
 {
     /**
-     * @param string $providerName 'meetup'
-     * @param string $providerClass 'Your\Name\Space\ClassName'
+     * @param string $providerName   'meetup'
+     * @param string $providerClass  'Your\Name\Space\ClassNameProvider'
+     * @param string $providerServer 'Your\Name\Space\ClassNameServer'
      */
-    public function extendSocialite($providerName, $providerClass)
+    public function extendSocialite($providerName, $providerClass, $providerServer = null)
     {
         $socialite = app()->make('Laravel\Socialite\Contracts\Factory');
+
         $socialite->extend(
             $providerName,
-            function ($app) use ($socialite, $providerName, $providerClass) {
-                $config = $app['config']['services.' . $providerName];
+            function ($app) use ($socialite, $providerName, $providerClass, $providerServer) {
+                $config = $app['config']['services.'.$providerName];
+
+                if (!empty($providerServer)) {
+                    return new $providerClass(
+                        $app['request'],
+                        new $providerServer([
+                            'identifier'   => $config['client_id'],
+                            'secret'       => $config['client_secret'],
+                            'callback_uri' => $config['redirect'],
+                        ])
+                    );
+                }
+
                 return $socialite->buildProvider($providerClass, $config);
             }
         );

--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -9,7 +9,7 @@ class SocialiteWasCalled
      */
     public function extendSocialite($providerName, $providerClass)
     {
-        $socialite = \App::make('Laravel\Socialite\Contracts\Factory');
+        $socialite = app()->make('Laravel\Socialite\Contracts\Factory');
         $socialite->extend(
             $providerName,
             function ($app) use ($socialite, $providerName, $providerClass) {


### PR DESCRIPTION
Using helper methods instead of Facades. This change is more cosmetic since I am not really a fan of Facades.

OAuth1 Providers can now be registered like.
```php
public function handle(SocialiteWasCalled $socialiteWasCalled)
{
    $socialiteWasCalled->extendSocialite(
        'tumblr',
        __NAMESPACE__.'\Provider',
        __NAMESPACE__.'\Server', // e.g. League\OAuth1\Client\Server\Tumblr
    );
}
```

In case [this pull request](https://github.com/laravel/socialite/pull/52) gets merged this line will be replaced.

```php
return new $providerClass(
    $app['request'],
    new $providerServer([
        'identifier'   => $config['client_id'],
        'secret'       => $config['client_secret'],
        'callback_uri' => $config['redirect'],
    ])
);
```

through this line.

```php
return new $providerClass($app['request'], $socialite->formatConfig($config));
```