### PR TITLE
More sensible minimum stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
       "email": "andy@awendt.com"
     }
   ],
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "autoload": {
     "psr-4": {
       "SocialiteProviders\\Manager\\": "src/"


### PR DESCRIPTION
No reason to need to have dev as the minimum stability.

Doing this means anyone with a stable composer can't install the package with out using the @dev tag