### PR TITLE
Add $additionalConfig to Config class

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -8,13 +8,13 @@ class Config implements Contracts\ConfigInterface
 
     protected $config;
 
-    public function __construct($key, $secret, $callbackUri)
+    public function __construct($key, $secret, $callbackUri, array $additionalConfig = [])
     {
-        $this->config = [
+        $this->config = array_merge([
             'client_id' => $key,
             'client_secret' => $secret,
             'redirect' => $callbackUri,
-        ];
+        ], $additionalConfig);
     }
 
     /**


### PR DESCRIPTION
I guess this would make it possible to finally use the StackExchange Provider properly if I didn't overlook anything with the new config feature.

```php
Route::group(['middleware' => ['web']], function () {
    \Route::get('/', function() {
		$key = 'SocialiteProviders.config.stackexchange';
		
		$config = new \SocialiteProviders\Manager\Config(
			env('STACKEXCHANGE_KEY'),
			env('STACKEXCHANGE_SECRET'),
			env('STACKEXCHANGE_REDIRECT_URI'),
			['key' => 'yourkeyfortheservice', 'site' => 'stackoverflow']
		);
		
		$this->app->instance($key, $config);

        return \Socialite::with('stackexchange')->redirect();
    });

    \Route::get('/callback', function () {
        $user = \Socialite::with('stackexchange')->user();

        dd($user);
    });
});
```