### PR TITLE
Properly set and get configuration, Style fixes

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -17,9 +17,9 @@ class Config implements Contracts\ConfigInterface
     public function __construct($key, $secret, $callbackUri, array $additionalProviderConfig = [])
     {
         $this->config = array_merge([
-            'client_id' => $key,
+            'client_id'     => $key,
             'client_secret' => $secret,
-            'redirect' => $callbackUri,
+            'redirect'      => $callbackUri,
         ], $additionalProviderConfig);
     }
 

--- a/src/ConfigTrait.php
+++ b/src/ConfigTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SocialiteProviders\Manager;
+
+use SocialiteProviders\Manager\Contracts\ConfigInterface as Config;
+
+trait ConfigTrait
+{
+    protected $config;
+
+    public function setConfig(Config $config)
+    {
+        $config = $config->get();
+
+        $this->config = $config;
+        $this->clientId = $config['client_id'];
+        $this->clientSecret = $config['client_secret'];
+        $this->redirectUrl = $config['redirect'];
+
+        return $this;
+    }
+
+    protected function getConfig($key = null, $default = null)
+    {
+        return $key ? array_get($this->config, $key, $default) : $this->config;
+    }
+
+    public static function additionalConfigKeys()
+    {
+        return [];
+    }
+}

--- a/src/Contracts/Helpers/ConfigRetrieverInterface.php
+++ b/src/Contracts/Helpers/ConfigRetrieverInterface.php
@@ -11,9 +11,9 @@ interface ConfigRetrieverInterface
      * @param string $providerIdentifier
      * @param array  $additionalConfigKeys
      *
+     * @throws MissingConfigException
      * @return ConfigInterface
      *
-     * @throws MissingConfigException
      */
     public function fromEnv($providerIdentifier, array $additionalConfigKeys = []);
 
@@ -21,9 +21,9 @@ interface ConfigRetrieverInterface
      * @param string $providerName
      * @param array  $additionalConfigKeys
      *
+     * @throws MissingConfigException
      * @return ConfigInterface
      *
-     * @throws MissingConfigException
      */
     public function fromServices($providerName, array $additionalConfigKeys = []);
 }

--- a/src/Contracts/OAuth1/ProviderInterface.php
+++ b/src/Contracts/OAuth1/ProviderInterface.php
@@ -11,5 +11,5 @@ interface ProviderInterface
      *
      * @return $this
      */
-    public function config(Config $config);
+    public function setConfig(Config $config);
 }

--- a/src/Contracts/OAuth2/ProviderInterface.php
+++ b/src/Contracts/OAuth2/ProviderInterface.php
@@ -12,5 +12,5 @@ interface ProviderInterface extends SocialiteOauth2ProviderInterface
      *
      * @return $this
      */
-    public function config(Config $config);
+    public function setConfig(Config $config);
 }

--- a/src/Helpers/ConfigRetriever.php
+++ b/src/Helpers/ConfigRetriever.php
@@ -27,9 +27,9 @@ class ConfigRetriever implements \SocialiteProviders\Manager\Contracts\Helpers\C
      * @param string $providerIdentifier
      * @param array  $additionalConfigKeys
      *
+     * @throws MissingConfigException
      * @return ConfigInterface
      *
-     * @throws MissingConfigException
      */
     public function fromEnv($providerIdentifier, array $additionalConfigKeys = [])
     {
@@ -48,9 +48,9 @@ class ConfigRetriever implements \SocialiteProviders\Manager\Contracts\Helpers\C
      * @param string $providerName
      * @param array  $additionalConfigKeys
      *
+     * @throws MissingConfigException
      * @return ConfigInterface
      *
-     * @throws MissingConfigException
      */
     public function fromServices($providerName, array $additionalConfigKeys = [])
     {
@@ -101,9 +101,9 @@ class ConfigRetriever implements \SocialiteProviders\Manager\Contracts\Helpers\C
     /**
      * @param string $key
      *
+     * @throws MissingConfigException
      * @return string
      *
-     * @throws MissingConfigException
      */
     private function getFromServices($key)
     {
@@ -117,9 +117,9 @@ class ConfigRetriever implements \SocialiteProviders\Manager\Contracts\Helpers\C
     /**
      * @param string $key
      *
+     * @throws MissingConfigException
      * @return string
      *
-     * @throws MissingConfigException
      */
     private function getFromEnv($key)
     {
@@ -136,21 +136,21 @@ class ConfigRetriever implements \SocialiteProviders\Manager\Contracts\Helpers\C
     /**
      * @param string $providerName
      *
+     * @throws MissingConfigException
      * @return array
      *
-     * @throws MissingConfigException
      */
     protected function getConfigFromServicesArray($providerName)
     {
         /** @var array $configArray */
         $configArray = config('services.'.$providerName);
-        
+
         if (empty($configArray)) {
             throw new MissingConfigException("There is no services entry for $providerName");
         }
-        
+
         $this->servicesArray = $configArray;
-        
+
         return $this->servicesArray;
     }
 }

--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -2,12 +2,14 @@
 
 namespace SocialiteProviders\Manager\OAuth1;
 
-use SocialiteProviders\Manager\Config;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use SocialiteProviders\Manager\ConfigTrait;
 
 abstract class AbstractProvider extends \Laravel\Socialite\One\AbstractProvider
 {
+    use ConfigTrait;
+
     /**
      * Indicates if the session state should be utilized.
      *
@@ -23,21 +25,6 @@ abstract class AbstractProvider extends \Laravel\Socialite\One\AbstractProvider
     public static function serviceContainerKey($providerName)
     {
         return SocialiteWasCalled::SERVICE_CONTAINER_PREFIX.$providerName;
-    }
-
-    /**
-     * @param Config $config
-     *
-     * @return $this
-     */
-    public function config(Config $config)
-    {
-        $config = $config->get();
-        $this->clientId = $config['client_id'];
-        $this->redirectUrl = $config['redirect'];
-        $this->clientSecret = $config['client_secret'];
-
-        return $this;
     }
 
     /**
@@ -136,23 +123,11 @@ abstract class AbstractProvider extends \Laravel\Socialite\One\AbstractProvider
         return $this->stateless;
     }
 
-    public static function additionalConfigKeys()
-    {
-        return [];
-    }
-
-    /**
-     * Map the raw user array to a Socialite User instance.
-     *
-     * @param  array  $user
-     * @return \Laravel\Socialite\Two\User
-     */
-    abstract protected function mapUserToObject(array $user);
-
     /**
      * Set the scopes of the requested access.
      *
-     * @param  array  $scopes
+     * @param array $scopes
+     *
      * @return $this
      */
     public function scopes(array $scopes)
@@ -165,7 +140,8 @@ abstract class AbstractProvider extends \Laravel\Socialite\One\AbstractProvider
     /**
      * Set the custom parameters of the request.
      *
-     * @param  array  $parameters
+     * @param array $parameters
+     *
      * @return $this
      */
     public function with(array $parameters)

--- a/src/OAuth1/Server.php
+++ b/src/OAuth1/Server.php
@@ -50,7 +50,7 @@ abstract class Server extends \League\OAuth1\Client\Server\Server
         }
 
         $uri = $this->urlTokenCredentials();
-        $bodyParameters = array('oauth_verifier' => $verifier);
+        $bodyParameters = ['oauth_verifier' => $verifier];
 
         $client = $this->createHttpClient();
 
@@ -63,7 +63,7 @@ abstract class Server extends \League\OAuth1\Client\Server\Server
         }
 
         return [
-            'tokenCredentials' => $this->createTokenCredentials($response->getBody()),
+            'tokenCredentials'        => $this->createTokenCredentials($response->getBody()),
             'credentialsResponseBody' => $response->getBody(),
         ];
     }
@@ -71,7 +71,8 @@ abstract class Server extends \League\OAuth1\Client\Server\Server
     /**
      * Set the scopes of the requested access.
      *
-     * @param  array  $scopes
+     * @param array $scopes
+     *
      * @return $this
      */
     public function scopes(array $scopes)
@@ -84,7 +85,8 @@ abstract class Server extends \League\OAuth1\Client\Server\Server
     /**
      * Set the custom parameters of the request.
      *
-     * @param  array  $parameters
+     * @param array $parameters
+     *
      * @return $this
      */
     public function with(array $parameters)
@@ -93,12 +95,13 @@ abstract class Server extends \League\OAuth1\Client\Server\Server
 
         return $this;
     }
-    
+
     /**
      * Format the given scopes.
      *
-     * @param  array  $scopes
-     * @param  string  $scopeSeparator
+     * @param array  $scopes
+     * @param string $scopeSeparator
+     *
      * @return string
      */
     protected function formatScopes(array $scopes, $scopeSeparator)

--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -6,10 +6,12 @@ use GuzzleHttp\ClientInterface;
 use Laravel\Socialite\Two\InvalidStateException;
 use SocialiteProviders\Manager\Contracts\OAuth2\ProviderInterface;
 use SocialiteProviders\Manager\SocialiteWasCalled;
-use SocialiteProviders\Manager\Contracts\ConfigInterface as Config;
+use SocialiteProviders\Manager\ConfigTrait;
 
 abstract class AbstractProvider extends \Laravel\Socialite\Two\AbstractProvider implements ProviderInterface
 {
+    use ConfigTrait;
+
     /**
      * @var array
      */
@@ -18,26 +20,6 @@ abstract class AbstractProvider extends \Laravel\Socialite\Two\AbstractProvider 
     public static function serviceContainerKey($providerName)
     {
         return SocialiteWasCalled::SERVICE_CONTAINER_PREFIX.$providerName;
-    }
-
-    public static function additionalConfigKeys()
-    {
-        return [];
-    }
-
-    /**
-     * @param Config $config
-     *
-     * @return $this
-     */
-    public function config(Config $config)
-    {
-        $config = $config->get();
-        $this->clientId = $config['client_id'];
-        $this->redirectUrl = $config['redirect'];
-        $this->clientSecret = $config['client_secret'];
-
-        return $this;
     }
 
     /**
@@ -75,7 +57,7 @@ abstract class AbstractProvider extends \Laravel\Socialite\Two\AbstractProvider 
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'headers' => ['Accept' => 'application/json'],
-            $postKey => $this->getTokenFields($code),
+            $postKey  => $this->getTokenFields($code),
         ]);
 
         $this->credentialsResponseBody = json_decode($response->getBody(), true);


### PR DESCRIPTION
This now allows to access the configuration from inside of Providers with a default value.

```php
return $this->buildAuthUrlFromBase($this->getConfig(
    'auth_base_uri',
    'https://open.weixin.qq.com/connect/oauth2/authorize'
), $state);
```