### PR TITLE
Set $stateless default to false

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -13,7 +13,7 @@ abstract class AbstractProvider extends \Laravel\Socialite\One\AbstractProvider
      *
      * @var bool
      */
-    protected $stateless = true;
+    protected $stateless = false;
 
     /**
      * @var array


### PR DESCRIPTION
Fixes #

## Changes proposed in this pull request:
-
-
-

In keeping with the laravel/socialite, and to allow user to specify whether they want to use stateless or not (using the `->stateless()` method), the default should be false.