### PR TITLE
Add protected function `parseAccessToken`

### DIFF
--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -65,4 +65,15 @@ abstract class AbstractProvider extends BaseProvider implements ProviderInterfac
 
         return $this->parseAccessToken($response->getBody());
     }
+
+    /**
+     * Get the access token from the token response body.
+     *
+     * @param  string  $body
+     * @return string
+     */
+    protected function parseAccessToken($body)
+    {
+        return json_decode($body, true)['access_token'];
+    }
 }


### PR DESCRIPTION
Fixes #

## Changes proposed in this pull request:

the class `Laravel\Socialite\Two\AbstractProvider` remove `parseAccessToken` function from 2.0.16

https://github.com/laravel/socialite/blob/v2.0.16/src/Two/AbstractProvider.php