### PR TITLE
Fix: Lumen stateless by default

### DIFF
--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -49,6 +49,9 @@ class SocialiteWasCalled
         $socialite->extend(
             $providerName,
             function () use ($provider) {
+                if (defined('SOCIALITEPROVIDERS_STATELESS') && SOCIALITEPROVIDERS_STATELESS) {
+                    return $provider->stateless();
+                }
                 return $provider;
             }
         );

--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -52,6 +52,7 @@ class SocialiteWasCalled
                 if (defined('SOCIALITEPROVIDERS_STATELESS') && SOCIALITEPROVIDERS_STATELESS) {
                     return $provider->stateless();
                 }
+                
                 return $provider;
             }
         );

--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -52,7 +52,7 @@ class SocialiteWasCalled
                 if (defined('SOCIALITEPROVIDERS_STATELESS') && SOCIALITEPROVIDERS_STATELESS) {
                     return $provider->stateless();
                 }
-                
+
                 return $provider;
             }
         );


### PR DESCRIPTION
When we call Socialite::with('some_provider')->redirect() in Lumen we expect a stateless provider ("Note: If you are using this with Lumen, all providers will automatically be stateless since Lumen does not keep track of state."), but get the provider with state.