### PR TITLE
Auth1 request headers discarding fix

### DIFF
--- a/src/OAuth1/Server.php
+++ b/src/OAuth1/Server.php
@@ -61,7 +61,7 @@ abstract class Server extends BaseServer
         $headers = $this->getHeaders($temporaryCredentials, 'POST', $uri, $bodyParameters);
 
         try {
-            $response = $client->post($uri, $headers, $bodyParameters)->send();
+            $response = $client->post($uri, ['headers' => $headers], $bodyParameters);
         } catch (BadResponseException $e) {
             return $this->handleTokenCredentialsBadResponse($e);
         }


### PR DESCRIPTION
Fixes
-  Applied headers are omitted in the post request.
## Changes proposed in this pull request:
-  Added `"headers"` array key as input parameter to wrap header data in order to make them compatible with the code below
  `$headers = isset($options['headers']) ? $options['headers'] : [];` in GuzzleHttp\Client@requestAsync L:111 
- Call to `send()` omitted in order to avoid `Call to undefined method GuzzleHttp\Psr7\Response::send()`. Probably a newer version of guzzle/psr7 does not implement `send()`
