### PR TITLE
fix put

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -66,12 +66,12 @@ abstract class AbstractProvider extends BaseProvider
     public function redirect()
     {
         if (!$this->isStateless()) {
-            $this->request->getSession()->set(
+            $this->request->getSession()->put(
                 'oauth.temp', $temp = $this->server->getTemporaryCredentials()
             );
         } else {
             $temp = $this->server->getTemporaryCredentials();
-            $this->request->session()->set('oauth_temp', serialize($temp));
+            $this->request->session()->put('oauth_temp', serialize($temp));
         }
 
         return new RedirectResponse($this->server->getAuthorizationUrl($temp));


### PR DESCRIPTION
Fixes #73 (also related to #72)

Laravel 5.4 removes `set()` method on session:

> All calls to the `->set()` method should be changed to `->put()`. Typically, Laravel applications would never call the set method since it has never been documented within the Laravel documentation. However, it is included here out of caution.

https://laravel.com/docs/5.4/upgrade
