### PR TITLE
Fix tests

### DIFF
--- a/tests/ConfigRetrieverTest.php
+++ b/tests/ConfigRetrieverTest.php
@@ -114,3 +114,16 @@ function config($key)
 {
     return ConfigRetrieverTest::$functions->config($key);
 }
+
+function app()
+{
+    return new applicationStub;
+}
+
+class applicationStub {
+
+    public function runningInConsole()
+    {
+        return false;
+    }
+}

--- a/tests/ManagerTestTrait.php
+++ b/tests/ManagerTestTrait.php
@@ -93,7 +93,7 @@ trait ManagerTestTrait
         static $provider = null;
 
         if (is_null($provider)) {
-            $provider = $this->mockStub('OAuth2ProviderStub');
+            $provider = $this->mockStub('OAuth2ProviderStub')->shouldDeferMissing();
         }
 
         return $provider;

--- a/tests/OAuth2ProviderTest.php
+++ b/tests/OAuth2ProviderTest.php
@@ -105,7 +105,7 @@ class OAuth2ProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = new OAuth2ProviderStub(\Mockery::mock(\Illuminate\Http\Request::class), 'client id', 'client secret', 'redirect url');
 
-        $result = $provider->config(new Config('key', 'secret', 'callback uri'));
+        $result = $provider->setConfig(new Config('key', 'secret', 'callback uri'));
 
         $this->assertEquals($provider, $result);
     }

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -21,8 +21,8 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
     public function redirectGeneratesTheProperSymfonyRedirectResponse()
     {
         $request = Request::create('foo');
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('set')->once();
+        $request->setLaravelSession($session = m::mock(\Illuminate\Contracts\Session\Session::class));
+        $session->shouldReceive('put')->once();
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
 


### PR DESCRIPTION
Fixes Tests failures due to missing stubbed methods and laravel now uses put in Illiminate 5.4 and setLaravelSession instead of setSession method.

## Changes proposed in this pull request:
- Fixes the tests.
