### PR TITLE
Add "get user profile" from `token` and `secret` method

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -57,6 +57,23 @@ abstract class AbstractProvider extends BaseProvider
 
         return $user;
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function userFromTokenAndSecret($token, $secret)
+    {
+        $tokenCredentials = new TokenCredentials();
+
+        $tokenCredentials->setIdentifier($token);
+        $tokenCredentials->setSecret($secret);
+
+        $user = $this->mapUserToObject((array)$this->server->getUserDetails($tokenCredentials));
+
+        $user->setToken($tokenCredentials->getIdentifier(), $tokenCredentials->getSecret());
+
+        return $user;
+    }
 
     /**
      * Redirect the user to the authentication page for the provider.


### PR DESCRIPTION
Fixes #

## Changes proposed in this pull request:
Adding get `userFromTokenAndSecret` method to correspond changes already merged into main Socialite package here https://github.com/laravel/socialite/pull/193

oAuth2 has a method `userFromToken` but oAuth1 doesn't...
It's critical for apps working through API only.
Without it I can't work with Twitter API 