### PR TITLE
Move tests to dev autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,11 @@
     },
     "autoload": {
         "psr-4": {
-            "SocialiteProviders\\Manager\\": "src/",
+            "SocialiteProviders\\Manager\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "SocialiteProviders\\Manager\\Test\\": "tests/"
         }
     },


### PR DESCRIPTION
Tests should be in `autoload-dev` section, because they are ignored in `.gitattributs`. This breaks parsing of autoloader file.
> /socialiteproviders/manager/tests" directory does not exist.