### PR TITLE
OAuth1 AbstractProvider missing ProviderInterface

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -7,9 +7,10 @@ use Laravel\Socialite\One\AbstractProvider as BaseProvider;
 use League\OAuth1\Client\Credentials\TokenCredentials;
 use SocialiteProviders\Manager\ConfigTrait;
 use SocialiteProviders\Manager\Contracts\ConfigInterface as Config;
+use SocialiteProviders\Manager\Contracts\OAuth1\ProviderInterface;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 
-abstract class AbstractProvider extends BaseProvider
+abstract class AbstractProvider extends BaseProvider implements ProviderInterface
 {
     use ConfigTrait;
 


### PR DESCRIPTION
`SocialiteProviders\Manager\Contracts\OAuth1\ProviderInterface` exists, but never used. I've just declared that `SocialiteProviders\Manager\OAuth1\AbstractProvider` implements it. The same as done in OAuth2. 

This shouldn't be a breaking change, because `AbstractProvider` uses `ConfigTrait` which completely satisfies this contract.