### PR TITLE
Fix outdated tests and code styling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,9 @@
     "authors": [{
         "name": "Andy Wendt",
         "email": "andy@awendt.com"
+    }, {
+        "name": "Anton Komarev",
+        "email": "a.komarev@cybercog.su"
     }],
     "require": {
         "php": "^5.6 || ^7.0",

--- a/src/Contracts/Helpers/ConfigRetrieverInterface.php
+++ b/src/Contracts/Helpers/ConfigRetrieverInterface.php
@@ -8,9 +8,9 @@ interface ConfigRetrieverInterface
      * @param string $providerName
      * @param array  $additionalConfigKeys
      *
-     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
-     *
      * @return \SocialiteProviders\Manager\Contracts\ConfigInterface
+     *
+     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     public function fromServices($providerName, array $additionalConfigKeys = []);
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,6 +2,8 @@
 
 namespace SocialiteProviders\Manager\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidArgumentException extends BaseInvalidArgumentException
 {
 }

--- a/src/Exception/MissingConfigException.php
+++ b/src/Exception/MissingConfigException.php
@@ -2,6 +2,8 @@
 
 namespace SocialiteProviders\Manager\Exception;
 
-class MissingConfigException extends \Exception
+use Exception;
+
+class MissingConfigException extends Exception
 {
 }

--- a/src/Helpers/ConfigRetriever.php
+++ b/src/Helpers/ConfigRetriever.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Manager\Helpers;
 
+use Closure;
 use SocialiteProviders\Manager\Config;
 use SocialiteProviders\Manager\Contracts\Helpers\ConfigRetrieverInterface;
 use SocialiteProviders\Manager\Exception\MissingConfigException;
@@ -32,9 +33,9 @@ class ConfigRetriever implements ConfigRetrieverInterface
      * @param string $providerName
      * @param array  $additionalConfigKeys
      *
-     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
-     *
      * @return \SocialiteProviders\Manager\Contracts\ConfigInterface
+     *
+     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     public function fromServices($providerName, array $additionalConfigKeys = [])
     {
@@ -59,7 +60,7 @@ class ConfigRetriever implements ConfigRetrieverInterface
      *
      * @return array
      */
-    protected function getConfigItems(array $configKeys, \Closure $keyRetrievalClosure)
+    protected function getConfigItems(array $configKeys, Closure $keyRetrievalClosure)
     {
         if (count($configKeys) < 1) {
             return [];
@@ -74,7 +75,7 @@ class ConfigRetriever implements ConfigRetrieverInterface
      *
      * @return array
      */
-    protected function retrieveItemsFromConfig(array $keys, \Closure $keyRetrievalClosure)
+    protected function retrieveItemsFromConfig(array $keys, Closure $keyRetrievalClosure)
     {
         $out = [];
 
@@ -88,9 +89,9 @@ class ConfigRetriever implements ConfigRetrieverInterface
     /**
      * @param string $key
      *
-     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
-     *
      * @return string
+     *
+     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     protected function getFromServices($key)
     {
@@ -112,22 +113,21 @@ class ConfigRetriever implements ConfigRetrieverInterface
     /**
      * @param string $providerName
      *
-     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
-     *
      * @return array
+     *
+     * @throws \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     protected function getConfigFromServicesArray($providerName)
     {
-        /** @var array $configArray */
-        $configArray = config("services.$providerName");
+        $configArray = config("services.{$providerName}");
 
         if (empty($configArray)) {
             // If we are running in console we should spoof values to make Socialite happy...
             if (app()->runningInConsole()) {
                 $configArray = [
-                    'client_id'     => "{$this->providerIdentifier}_KEY",
+                    'client_id' => "{$this->providerIdentifier}_KEY",
                     'client_secret' => "{$this->providerIdentifier}_SECRET",
-                    'redirect'      => "{$this->providerIdentifier}_REDIRECT_URI",
+                    'redirect' => "{$this->providerIdentifier}_REDIRECT_URI",
                 ];
             } else {
                 throw new MissingConfigException("There is no services entry for $providerName");

--- a/tests/ConfigRetrieverTest.php
+++ b/tests/ConfigRetrieverTest.php
@@ -2,6 +2,8 @@
 
 namespace SocialiteProviders\Manager\Test;
 
+use Mockery as m;
+use SocialiteProviders\Manager\Exception\MissingConfigException;
 use SocialiteProviders\Manager\Helpers\ConfigRetriever;
 
 class ConfigRetrieverTest extends \PHPUnit_Framework_TestCase
@@ -10,27 +12,37 @@ class ConfigRetrieverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     public function it_throws_if_there_is_a_problem_with_the_services_config()
     {
-        $providerName = 'test';
+        $this->expectException(MissingConfigException::class);
 
-        self::$functions->shouldReceive('config')->with("services.$providerName")->once()->andReturn(null);
+        $providerName = 'test';
+        self::$functions
+            ->shouldReceive('config')
+            ->with("services.{$providerName}")
+            ->once()
+            ->andReturn(null);
         $configRetriever = new ConfigRetriever();
+
         $configRetriever->fromServices($providerName)->get();
     }
 
     /**
      * @test
-     * @expectedException \SocialiteProviders\Manager\Exception\MissingConfigException
      */
     public function it_throws_if_there_are_missing_items_in_the_services_config()
     {
-        $providerName = 'test';
+        $this->expectException(MissingConfigException::class);
 
-        self::$functions->shouldReceive('config')->with("services.$providerName")->once()->andReturn([]);
+        $providerName = 'test';
+        self::$functions
+            ->shouldReceive('config')
+            ->with("services.{$providerName}")
+            ->once()
+            ->andReturn([]);
         $configRetriever = new ConfigRetriever();
+
         $configRetriever->fromServices($providerName)->get();
     }
 
@@ -44,22 +56,25 @@ class ConfigRetrieverTest extends \PHPUnit_Framework_TestCase
         $secret = 'secret';
         $uri = 'uri';
         $additionalConfigItem = 'test';
-
         $config = [
-            'client_id'     => $key,
+            'client_id' => $key,
             'client_secret' => $secret,
-            'redirect'      => $uri,
-            'additional'    => $additionalConfigItem,
+            'redirect' => $uri,
+            'additional' => $additionalConfigItem,
         ];
-
-        self::$functions->shouldReceive('config')->with("services.$providerName")->once()->andReturn($config);
+        self::$functions
+            ->shouldReceive('config')
+            ->with("services.{$providerName}")
+            ->once()
+            ->andReturn($config);
         $configRetriever = new ConfigRetriever();
+
         $result = $configRetriever->fromServices($providerName, ['additional'])->get();
 
-        $this->assertEquals($key, $result['client_id']);
-        $this->assertEquals($secret, $result['client_secret']);
-        $this->assertEquals($uri, $result['redirect']);
-        $this->assertEquals($additionalConfigItem, $result['additional']);
+        $this->assertSame($key, $result['client_id']);
+        $this->assertSame($secret, $result['client_secret']);
+        $this->assertSame($uri, $result['redirect']);
+        $this->assertSame($additionalConfigItem, $result['additional']);
     }
 }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,11 +12,10 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $key = 'key';
         $secret = 'secret';
         $callbackUri = 'uri';
-
         $result = [
-            'client_id'     => $key,
+            'client_id' => $key,
             'client_secret' => $secret,
-            'redirect'      => $callbackUri,
+            'redirect' => $callbackUri,
         ];
 
         $config = new Config($key, $secret, $callbackUri);
@@ -32,14 +31,12 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $key = 'key';
         $secret = 'secret';
         $callbackUri = 'uri';
-
         $result = [
-            'client_id'     => $key,
+            'client_id' => $key,
             'client_secret' => $secret,
-            'redirect'      => $callbackUri,
-            'additional'    => true,
+            'redirect' => $callbackUri,
+            'additional' => true,
         ];
-
         $additional = ['additional' => true];
 
         $config = new Config($key, $secret, $callbackUri, $additional);

--- a/tests/ManagerTestTrait.php
+++ b/tests/ManagerTestTrait.php
@@ -2,6 +2,9 @@
 
 namespace SocialiteProviders\Manager\Test;
 
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Http\Request as HttpRequest;
+use Laravel\Socialite\SocialiteManager;
 use Mockery as m;
 use SocialiteProviders\Manager\Config;
 use SocialiteProviders\Manager\Contracts\Helpers\ConfigRetrieverInterface;
@@ -21,21 +24,51 @@ trait ManagerTestTrait
     }
 
     /**
-     * @return m\MockInterface
+     * @return \Mockery\MockInterface|\SocialiteProviders\Manager\Contracts\Helpers\ConfigRetrieverInterface
      */
     protected function configRetrieverMock()
     {
         return m::mock(ConfigRetrieverInterface::class);
     }
 
-    protected function expectManagerInvalidArgumentException()
+    /**
+     * @return \Mockery\MockInterface|\Illuminate\Contracts\Container\Container
+     */
+    protected function appMock()
     {
-        $this->setExpectedException(\SocialiteProviders\Manager\Exception\InvalidArgumentException::class);
+        return m::mock(ContainerContract::class);
+    }
+
+    /**
+     * @return \Mockery\MockInterface|\Laravel\Socialite\SocialiteManager
+     */
+    protected function socialiteMock()
+    {
+        return m::mock(SocialiteManager::class);
+    }
+
+    /**
+     * @return \Mockery\MockInterface|\Illuminate\Http\Request
+     */
+    protected function buildRequest()
+    {
+        return m::mock(HttpRequest::class);
     }
 
     protected function configObject()
     {
         return new Config('test', 'test', 'test');
+    }
+
+    protected function configRetrieverMockWithDefaultExpectations($providerName, $providerClass)
+    {
+        $configRetriever = $this->configRetrieverMock();
+        $configRetriever
+            ->shouldReceive('fromServices')
+            ->with($providerName, $providerClass::additionalConfigKeys())
+            ->andReturn($this->configObject());
+
+        return $configRetriever;
     }
 
     /**
@@ -44,9 +77,9 @@ trait ManagerTestTrait
     protected function config()
     {
         return [
-            'client_id'     => 'test',
+            'client_id' => 'test',
             'client_secret' => 'test',
-            'redirect'      => 'test',
+            'redirect' => 'test',
         ];
     }
 
@@ -58,26 +91,10 @@ trait ManagerTestTrait
     protected function oauth1FormattedConfig(array $config)
     {
         return [
-            'identifier'   => $config['client_id'],
-            'secret'       => $config['client_secret'],
+            'identifier' => $config['client_id'],
+            'secret' => $config['client_secret'],
             'callback_uri' => $config['redirect'],
         ];
-    }
-
-    /**
-     * @return \Mockery\MockInterface
-     */
-    protected function appMock()
-    {
-        return m::mock(\Illuminate\Container\Container::class);
-    }
-
-    /**
-     * @return \Mockery\MockInterface
-     */
-    protected function socialiteMock()
-    {
-        return m::mock(\Laravel\Socialite\SocialiteManager::class);
     }
 
     protected function oauth2ProviderStub()
@@ -102,17 +119,17 @@ trait ManagerTestTrait
         return $provider;
     }
 
-    protected function oauth1ProviderStubName()
+    protected function oauth1ProviderStubClass()
     {
         return $this->fullStubClassName('OAuth1ProviderStub');
     }
 
-    protected function oauth1ServerStubName()
+    protected function oauth1ServerStubClass()
     {
         return $this->fullStubClassName('OAuth1ServerStub');
     }
 
-    protected function oauth2ProviderStubName()
+    protected function oauth2ProviderStubClass()
     {
         return $this->fullStubClassName('OAuth2ProviderStub');
     }
@@ -120,7 +137,7 @@ trait ManagerTestTrait
     /**
      * @param string $stub
      *
-     * @return m\MockInterface
+     * @return \Mockery\MockInterface
      */
     protected function mockStub($stub)
     {
@@ -135,44 +152,6 @@ trait ManagerTestTrait
     protected function fullStubClassName($stub)
     {
         return __NAMESPACE__.'\Stubs\\'.$stub;
-    }
-
-    /**
-     * @param string $class
-     *
-     * @return string
-     */
-    protected function fullClassName($class)
-    {
-        return __NAMESPACE__.'\\'.$class;
-    }
-
-    /**
-     * @param string $providerName
-     *
-     * @return array
-     */
-    protected function servicesArray($providerName)
-    {
-        return [$this->providerConfigKey($providerName) => $this->config()];
-    }
-
-    /**
-     * @param string $providerName
-     *
-     * @return string
-     */
-    protected function providerConfigKey($providerName)
-    {
-        return 'services.'.$providerName;
-    }
-
-    /**
-     * @return m\MockInterface
-     */
-    protected function buildRequest()
-    {
-        return m::mock(\Illuminate\Http\Request::class);
     }
 
     /**

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -2,11 +2,15 @@
 
 namespace SocialiteProviders\Manager\Test;
 
+use Illuminate\Contracts\Session\Session as SessionContract;
 use Illuminate\Http\Request;
+use Laravel\Socialite\Two\User as SocialiteOAuth2User;
 use Mockery as m;
 use PHPUnit_Framework_TestCase;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class OAuthTwoTest extends PHPUnit_Framework_TestCase
 {
@@ -15,13 +19,16 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function redirectGeneratesTheProperSymfonyRedirectResponse()
     {
+        $session = m::mock(SessionContract::class);
         $request = Request::create('foo');
-        $request->setLaravelSession($session = m::mock(\Illuminate\Contracts\Session\Session::class));
-        $session->shouldReceive('put')->once();
+        $request->setLaravelSession($session);
+        $session
+            ->shouldReceive('put')
+            ->once();
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
         $response = $provider->redirect();
 
-        $this->assertInstanceOf(\Symfony\Component\HttpFoundation\RedirectResponse::class, $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('http://auth.url', $response->getTargetUrl());
     }
 
@@ -40,15 +47,37 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function userReturnsAUserInstanceForTheAuthenticatedRequest()
     {
-        $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $session = m::mock(SessionInterface::class);
+        $request = Request::create('foo', 'GET', [
+            'state' => str_repeat('A', 40),
+            'code' => 'code',
+        ]);
+        $request->setSession($session);
+        $session
+            ->shouldReceive('pull')
+            ->once()
+            ->with('state')
+            ->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock('StdClass');
-        $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
-        ])->andReturn($response = m::mock('StdClass'));
-        $response->shouldReceive('getBody')->andReturn('{"access_token": "access_token", "test": "test"}');
+        $provider->http
+            ->shouldReceive('post')
+            ->once()
+            ->with('http://token.url', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'form_params' => [
+                    'client_id' => 'client_id',
+                    'client_secret' => 'client_secret',
+                    'code' => 'code',
+                    'redirect_uri' => 'redirect_uri',
+                ],
+            ])
+            ->andReturn($response = m::mock('StdClass'));
+        $response
+            ->shouldReceive('getBody')
+            ->andReturn('{"access_token": "access_token", "test": "test"}');
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
@@ -60,16 +89,37 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function access_token_response_body_is_accessible_from_user()
     {
+        $session = m::mock(SessionInterface::class);
         $accessTokenResponseBody = '{"access_token": "access_token", "test": "test"}';
-        $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $request = Request::create('foo', 'GET', [
+            'state' => str_repeat('A', 40),
+            'code' => 'code',
+        ]);
+        $request->setSession($session);
+        $session
+            ->shouldReceive('pull')
+            ->once()
+            ->with('state')
+            ->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock('StdClass');
-        $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
-        ])->andReturn($response = m::mock('StdClass'));
-        $response->shouldReceive('getBody')->andReturn($accessTokenResponseBody);
+        $provider->http
+            ->shouldReceive('post')
+            ->once()
+            ->with('http://token.url', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ], 'form_params' => [
+                    'client_id' => 'client_id',
+                    'client_secret' => 'client_secret',
+                    'code' => 'code',
+                    'redirect_uri' => 'redirect_uri',
+                ],
+            ])
+            ->andReturn($response = m::mock('StdClass'));
+        $response
+            ->shouldReceive('getBody')
+            ->andReturn($accessTokenResponseBody);
         $user = $provider->user();
 
         $this->assertInstanceOf(User::class, $user);
@@ -82,19 +132,41 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function regular_laravel_socialite_class_works_as_well()
     {
+        $session = m::mock(SessionInterface::class);
         $accessTokenResponseBody = '{"access_token": "access_token", "test": "test"}';
-        $request = Request::create('foo', 'GET', ['state' => str_repeat('A', 40), 'code' => 'code']);
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $request = Request::create('foo', 'GET', [
+            'state' => str_repeat('A', 40),
+            'code' => 'code',
+        ]);
+        $request->setSession($session);
+        $session
+            ->shouldReceive('pull')
+            ->once()
+            ->with('state')
+            ->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect_uri');
         $provider->http = m::mock('StdClass');
-        $provider->http->shouldReceive('post')->once()->with('http://token.url', [
-            'headers' => ['Accept' => 'application/json'], 'form_params' => ['client_id' => 'client_id', 'client_secret' => 'client_secret', 'code' => 'code', 'redirect_uri' => 'redirect_uri'],
-        ])->andReturn($response = m::mock('StdClass'));
-        $response->shouldReceive('getBody')->andReturn($accessTokenResponseBody);
+        $provider->http
+            ->shouldReceive('post')
+            ->once()
+            ->with('http://token.url', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'form_params' => [
+                    'client_id' => 'client_id',
+                    'client_secret' => 'client_secret',
+                    'code' => 'code',
+                    'redirect_uri' => 'redirect_uri',
+                ],
+            ])
+            ->andReturn($response = m::mock('StdClass'));
+        $response
+            ->shouldReceive('getBody')
+            ->andReturn($accessTokenResponseBody);
         $user = $provider->user();
 
-        $this->assertInstanceOf(\Laravel\Socialite\Two\User::class, $user);
+        $this->assertInstanceOf(SocialiteOAuth2User::class, $user);
         $this->assertEquals('foo', $user->id);
     }
 
@@ -104,11 +176,19 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function exceptionIsThrownIfStateIsInvalid()
     {
-        $request = Request::create('foo', 'GET', ['state' => str_repeat('B', 40), 'code' => 'code']);
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state')->andReturn(str_repeat('A', 40));
+        $session = m::mock(SessionInterface::class);
+        $request = Request::create('foo', 'GET', [
+            'state' => str_repeat('B', 40),
+            'code' => 'code',
+        ]);
+        $request->setSession($session);
+        $session
+            ->shouldReceive('pull')
+            ->once()
+            ->with('state')
+            ->andReturn(str_repeat('A', 40));
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
-        $user = $provider->user();
+        $provider->user();
     }
 
     /**
@@ -117,11 +197,18 @@ class OAuthTwoTest extends PHPUnit_Framework_TestCase
      */
     public function exceptionIsThrownIfStateIsNotSet()
     {
-        $request = Request::create('foo', 'GET', ['state' => 'state', 'code' => 'code']);
-        $request->setSession($session = m::mock(\Symfony\Component\HttpFoundation\Session\SessionInterface::class));
-        $session->shouldReceive('pull')->once()->with('state');
+        $session = m::mock(SessionInterface::class);
+        $request = Request::create('foo', 'GET', [
+            'state' => 'state',
+            'code' => 'code',
+        ]);
+        $request->setSession($session);
+        $session
+            ->shouldReceive('pull')
+            ->once()
+            ->with('state');
         $provider = new OAuthTwoTestProviderStub($request, 'client_id', 'client_secret', 'redirect');
-        $user = $provider->user();
+        $provider->user();
     }
 }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -16,12 +16,19 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function it_fires_an_event()
     {
         $socialiteWasCalledMock = m::mock(SocialiteWasCalled::class);
-        self::$functions->shouldReceive('app')->with(SocialiteWasCalled::class)->once()->andReturn($socialiteWasCalledMock);
+        self::$functions
+            ->shouldReceive('app')
+            ->with(SocialiteWasCalled::class)
+            ->once()
+            ->andReturn($socialiteWasCalledMock);
 
-        self::$functions->shouldReceive('event')->with($socialiteWasCalledMock)->once();
+        self::$functions
+            ->shouldReceive('event')
+            ->with($socialiteWasCalledMock)
+            ->once();
 
-        $sp = new ServiceProvider($this->appMock());
-        $sp->boot();
+        $serviceProvider = new ServiceProvider($this->appMock());
+        $serviceProvider->boot();
 
         $this->assertTrue(true);
     }

--- a/tests/Stubs/OAuth1ServerStub.php
+++ b/tests/Stubs/OAuth1ServerStub.php
@@ -55,7 +55,7 @@ class OAuth1ServerStub extends Server
      * @param mixed            $data
      * @param TokenCredentials $tokenCredentials
      *
-     * @return User
+     * @return \SocialiteProviders\Manager\OAuth1\User
      */
     public function userDetails($data, TokenCredentials $tokenCredentials)
     {


### PR DESCRIPTION
This PR is related to #133 but not resolves it, because it's just a first step to make all the tests working before starting refactoring process.

1. Tests were fixed and updated to actual codebase.
2. Outdated DocBlocks were actualized.
3. To follow the same code style convention with Laravel all FQCN classes were imported.
4. `SocialiteWasCalled` resolving of `ConfigRetrieverInterface` was moved back to `__construct` method [as it was one year ago](https://github.com/SocialiteProviders/Manager/blob/1de3f3d874392da6f1a4c0bf30d843e9cd903ea7/src/SocialiteWasCalled.php).

I've not modified anything what could possibly be a breaking change.
Changing of `SocialiteWasCalled` event shouldn't be breaking because it's called out of the container in `boot` method of the `ServiceProvider`:
```php
public function boot()
{
    $socialiteWasCalled = app(SocialiteWasCalled::class);

    event($socialiteWasCalled);
}
```