### PR TITLE
emergency repair: guzzle config accept empty array not null.

### DIFF
--- a/src/Helpers/ConfigRetriever.php
+++ b/src/Helpers/ConfigRetriever.php
@@ -95,7 +95,7 @@ class ConfigRetriever implements ConfigRetrieverInterface
 
         // ADDITIONAL value is empty
         if (!$keyExists && $this->isAdditionalConfig($key)) {
-            return;
+            return $key == 'guzzle' ? [] : null ;
         }
 
         // REQUIRED value is empty


### PR DESCRIPTION
emergency repair #143