### PR TITLE
Make ConfigRetriever overridable

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,8 +29,10 @@ class ServiceProvider extends SocialiteServiceProvider
             define('SOCIALITEPROVIDERS_STATELESS', true);
         }
 
-        $this->app->singleton(ConfigRetrieverInterface::class, function () {
-            return new ConfigRetriever();
-        });
+        if (!$this->app->bound(ConfigRetrieverInterface::class)) {
+            $this->app->singleton(ConfigRetrieverInterface::class, function () {
+                return new ConfigRetriever();
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes #133 

I've found very simple and non breaking solution.

## Changes proposed in this pull request:
- Check if `ConfigRetriever` wasn't bound already