### PR TITLE
Added SocialiteWasCalled event to booted callbacks

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,9 +13,11 @@ class ServiceProvider extends SocialiteServiceProvider
      */
     public function boot()
     {
-        $socialiteWasCalled = app(SocialiteWasCalled::class);
+        $this->app->booted(function () {
+            $socialiteWasCalled = app(SocialiteWasCalled::class);
 
-        event($socialiteWasCalled);
+            event($socialiteWasCalled);
+        });
     }
 
     /**

--- a/tests/ManagerTestTrait.php
+++ b/tests/ManagerTestTrait.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Manager\Test;
 
 use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\Request as HttpRequest;
 use Laravel\Socialite\SocialiteManager;
 use Mockery as m;
@@ -37,6 +38,19 @@ trait ManagerTestTrait
     protected function appMock()
     {
         return m::mock(ContainerContract::class);
+    }
+
+    /**
+     * @return \Mockery\MockInterface|\Illuminate\Contracts\Foundation\Application
+     */
+    protected function appMockWithBooted() {
+        $app = m::mock(Application::class);
+        $app->shouldReceive('booted')->with(m::on(function ($callback) {
+            $callback();
+            return true;
+        }));
+
+        return $app;
     }
 
     /**

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -27,7 +27,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
             ->with($socialiteWasCalledMock)
             ->once();
 
-        $serviceProvider = new ServiceProvider($this->appMock());
+        $serviceProvider = new ServiceProvider($this->appMockWithBooted());
         $serviceProvider->boot();
 
         $this->assertTrue(true);


### PR DESCRIPTION
Fixes #

## Changes proposed in this pull request:
- SocialiteWasCalled event was being fired before event listeners were registered
- This needed to be added to the applications bootedCallbacks array