### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Total Downloads](https://poser.pugx.org/socialiteproviders/manager/downloads.svg)](https://packagist.org/packages/socialiteproviders/manager) 
 [![Latest Unstable Version](https://poser.pugx.org/socialiteproviders/manager/v/unstable.svg)](https://packagist.org/packages/socialiteproviders/manager) 
 [![License](https://poser.pugx.org/socialiteproviders/manager/license.svg)](https://packagist.org/packages/socialiteproviders/manager) 
-[![Stories in Ready](https://badge.waffle.io/SocialiteProviders/Manager.png?label=ready&title=Ready)](http://waffle.io/SocialiteProviders/Manager)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/ddb2f0df-6d85-431c-8e68-6164b08dd852/small.png)](https://insight.sensiolabs.com/projects/ddb2f0df-6d85-431c-8e68-6164b08dd852)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A package for Laravel Socialite that allows you to easily add new providers or o
 
 ## Reference
 
-* [Laravel docs about events](http://laravel.com/docs/5.0/events)
+* [Laravel docs about events](https://laravel.com/docs/6.x/events)
 * [Laracasts video on events in Laravel 5](https://laracasts.com/lessons/laravel-5-events)
 * [Laravel Socialite Docs](https://github.com/laravel/socialite)  
 * [Laracasts Socialite video](https://laracasts.com/series/whats-new-in-laravel-5/episodes/9)
@@ -42,7 +42,7 @@ A package for Laravel Socialite that allows you to easily add new providers or o
 
 Below is an example handler.  You need to add this full class name to the `listen[]` in the `EventServiceProvider`.
 
-* [See also the Laravel docs about events](http://laravel.com/docs/5.0/events).
+* [See also the Laravel docs about events](https://laravel.com/docs/6.x/events).
 * `providername` is the name of the provider such as `meetup`.
 * You will need to change your the namespacing and class names of course.  
 


### PR DESCRIPTION
waffle.io shut-down in may 2019, so i remove broken URL of waffle.io in README.md
also update the URL of laravel's documentation.