### PR TITLE
Adds getTemporaryCredentials method for assistance in stateless Oauth1 calls.

### DIFF
--- a/src/OAuth1/AbstractProvider.php
+++ b/src/OAuth1/AbstractProvider.php
@@ -102,6 +102,21 @@ abstract class AbstractProvider extends BaseProvider implements ProviderInterfac
     }
 
     /**
+     * Returns temporary credentials for stateless auth.
+     *
+     * @return array
+     */
+    public function getTemporaryCredentials()
+    {
+        $temp = $this->server->getTemporaryCredentials();
+
+        return [
+            'identifier' => $temp->getIdentifier(),
+            'secret' => $temp->getSecret(),
+        ];
+    }
+
+    /**
      * Indicates that the provider should operate as stateless.
      *
      * @param mixed $stateless


### PR DESCRIPTION
## Fixes 

Even when specifying `stateless()`, temporary credentials are stored in the app's configured session provider. For purely-stateless applications, this requires additional steps to complete some OAuth1 calls, specifically those required by Twitter.

For gaining access via OAuth1 with Twitter, we need the temporary credentials created in the `redirect()` method of `AbstractProvider`. As this method returns a (redirect) Response object, obtaining the details needed for the completion of a stateless Oauth1 connection is not explicitly provided. 

For example: obtaining the original `oauth_token` for creating the URL used to generate the Twitter Oauth1 dialog.

This method simply exposes the values called from `$this->server->getTemporaryCredentials()` as a public method returning an array containing both the `identifier` and `secret` values.

## Changes proposed in this pull request:
- Adds getTemporaryCredentials() method to `SocialiteProviders\Manager\OAuth1\AbstractProvider`

## Testing

I have tested this and it works perfectly for my needs and some of the needs I've found while searching for other solutions for apps without session storage available for separate requests.

I did not find any tests pertaining explicitly to the AbstractProvider in the existing test suite, so I haven't added any.

## Documentation

I will create a separate PR to update this method in the documentation if it is accepted and merged.

Thank you!