### PR TITLE
Fix docblock.

### DIFF
--- a/src/OAuth2/AbstractProvider.php
+++ b/src/OAuth2/AbstractProvider.php
@@ -56,7 +56,7 @@ abstract class AbstractProvider extends BaseProvider implements ProviderInterfac
     /**
      * Get the access token from the token response body.
      *
-     * @param string $body
+     * @param array $body
      *
      * @return string
      */
@@ -68,7 +68,7 @@ abstract class AbstractProvider extends BaseProvider implements ProviderInterfac
     /**
      * Get the refresh token from the token response body.
      *
-     * @param string $body
+     * @param array $body
      *
      * @return string
      */
@@ -80,7 +80,7 @@ abstract class AbstractProvider extends BaseProvider implements ProviderInterfac
     /**
      * Get the expires in from the token response body.
      *
-     * @param string $body
+     * @param array $body
      *
      * @return string
      */


### PR DESCRIPTION

## Changes proposed in this pull request:

- This PR fixes bad docblocks: `Arr::get` only accept an array as first argument, not a string
