### PR TITLE
Introduce refresh and revoke interfaces for OAuth2 providers

### DIFF
--- a/src/Contracts/OAuth2/RefreshTokensInterface.php
+++ b/src/Contracts/OAuth2/RefreshTokensInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SocialiteProviders\Manager\Contracts\OAuth2;
+
+use Laravel\Socialite\Two\ProviderInterface as SocialiteOauth2ProviderInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface RefreshTokensInterface extends SocialiteOauth2ProviderInterface
+{
+    /**
+     * @param string $refreshToken
+     * @return ResponseInterface
+     */
+    public function refreshToken(string $refreshToken) : ResponseInterface;
+
+    /**
+     * @param string $refreshToken
+     * @return array
+     */
+    public function getRefreshTokenResponse(string $refreshToken) : array;
+}

--- a/src/Contracts/OAuth2/RevokeTokensInterface.php
+++ b/src/Contracts/OAuth2/RevokeTokensInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SocialiteProviders\Manager\Contracts\OAuth2;
+
+use Laravel\Socialite\Two\ProviderInterface as SocialiteOauth2ProviderInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface RevokeTokensInterface extends SocialiteOauth2ProviderInterface
+{
+    /**
+     * @param string $token
+     * @param string $hint optional hint, either 'access_token' or 'refresh_token'
+     * @return ResponseInterface
+     */
+    public function revokeToken(string $token, string $hint = '') : ResponseInterface;
+
+    /**
+     * @param string $token
+     * @param string $hint optional hint, either 'access_token' or 'refresh_token'
+     * @return array
+     */
+    public function getRevokeTokenResponse(string $token, string $hint = '') : array;
+}


### PR DESCRIPTION
This PR proposes 2 new interfaces:

* `RefreshTokensInterface` - can be implemented by OAuth2 providers that support refreshing an access token
* `RevokeTokensInterface` - can be implemented by OAuth2 providers that support revoking an access/refresh token

The interfaces are based on the current implementations in SocialiteProviders/Providers repo.

For reasoning, see [this discussion](https://github.com/SocialiteProviders/Providers/discussions/1032).

**Refreshing tokens:**

* [Apple refreshToken](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Apple/Provider.php#L293-L303)
* [OKTA getRefreshTokenResponse](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Okta/Provider.php#L127-L145)
* [Onelogin getRefreshTokenResponse](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Onelogin/Provider.php#L105-L123)
* [Procore getRefreshTokenResponse](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Procore/Provider.php#L37-L45)

**Revoking tokens:**

* [Yiban revokeToken](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Yiban/Provider.php#L33-L44)
* [OKTA revokeToken](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Okta/Provider.php#L197-L215)
* [Onelogin revokeToken](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Onelogin/Provider.php#L177-L195)
* [Apple revokeToken](https://github.com/SocialiteProviders/Providers/blob/216655be133c7162e1b98caa292f69469ff64d90/src/Apple/Provider.php#L260-L278)

Both interfaces define 2 methods - one for getting the raw response, the other for getting the parsed response. The reason for this is to provide backwards compatibility with existing implementations. For example, if Apple provider will implement the `RefreshTokensInterface`, the existing `refreshToken` method will continue to work as-is, so if a Laravel site is calling this method, it will continue to work.

Ideally, the implementation of the parsed response method is to call the raw response method and parse the response, ie:

```php
public function getRefreshTokenResponse(string $refreshToken) : array {
    return json_decode((string) $this->refreshToken($refreshToken)->getBody(), true);
}
```

**Other considerations / open questions**
* Should we define `getRefreshTokenUrl()` and `getRevokeTokenUrl()` methods? Some existing providers define such methods, but having these in the contract would make sense if we also provide a trait that implements these methods.
* Tied to the above - should we have matching traits that implement both interfaces?

