### PR TITLE
Stop supporting PHP < 8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [ pull_request, push ]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 
 jobs:
   test:
@@ -11,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         coverage: [ 'none' ]
-        php-versions: [ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.0', '8.1', '8.2' ]
         exclude:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
         include:
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             coverage: 'xdebug'
 
     name: PHP ${{ matrix.php-versions }}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "laravel/socialite": "~5.0"
     },

--- a/src/Helpers/ConfigRetriever.php
+++ b/src/Helpers/ConfigRetriever.php
@@ -45,9 +45,7 @@ class ConfigRetriever implements ConfigRetrieverInterface
             $this->getFromServices('client_id'),
             $this->getFromServices('client_secret'),
             $this->getFromServices('redirect'),
-            $this->getConfigItems($additionalConfigKeys, function ($key) {
-                return $this->getFromServices(strtolower($key));
-            })
+            $this->getConfigItems($additionalConfigKeys, fn($key) => $this->getFromServices(strtolower($key)))
         );
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -40,9 +40,7 @@ class ServiceProvider extends SocialiteServiceProvider
         }
 
         if (! $this->app->bound(ConfigRetrieverInterface::class)) {
-            $this->app->singleton(ConfigRetrieverInterface::class, function () {
-                return new ConfigRetriever();
-            });
+            $this->app->singleton(ConfigRetrieverInterface::class, fn() => new ConfigRetriever());
         }
     }
 }

--- a/src/SocialiteWasCalled.php
+++ b/src/SocialiteWasCalled.php
@@ -20,10 +20,7 @@ class SocialiteWasCalled
      */
     protected $app;
 
-    /**
-     * @var \SocialiteProviders\Manager\Contracts\Helpers\ConfigRetrieverInterface
-     */
-    private $configRetriever;
+    private ConfigRetrieverInterface $configRetriever;
 
     /**
      * @param  \Illuminate\Contracts\Container\Container  $app

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -54,9 +54,7 @@ class ConfigTest extends TestCase
         $key = 'key';
         $secret = 'secret';
         $callbackUri = 'uri';
-        $callbackFunc = function () use ($callbackUri) {
-            return $callbackUri;
-        };
+        $callbackFunc = fn() => $callbackUri;
         $result = [
             'client_id' => $key,
             'client_secret' => $secret,


### PR DESCRIPTION
This PR is related to https://github.com/SocialiteProviders/Providers/pull/1060 and drops support for PHP versions < 8.0