### PR TITLE
Bump to laravel/socialite:^5.2 and phpunit/phpunit:^9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "laravel/socialite": "~5.0"
+        "laravel/socialite": "^5.2"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "phpunit/phpunit": "^6.0 || ^9.0"
+        "phpunit/phpunit": "^9.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "illuminate/support": "^6.20 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "laravel/socialite": "^5.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "socialiteproviders/manager",
     "description": "Easily add new or override built-in providers in Laravel Socialite.",
+    "license": "MIT",
     "keywords": [
         "laravel",
         "manager",
@@ -8,8 +9,6 @@
         "providers",
         "socialite"
     ],
-    "homepage": "https://socialiteproviders.com",
-    "license": "MIT",
     "authors": [
         {
             "name": "Andy Wendt",
@@ -29,6 +28,11 @@
             "homepage": "https://atymic.dev"
         }
     ],
+    "homepage": "https://socialiteproviders.com",
+    "support": {
+        "issues": "https://github.com/socialiteproviders/manager/issues",
+        "source": "https://github.com/socialiteproviders/manager"
+    },
     "require": {
         "php": "^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
@@ -38,16 +42,7 @@
         "mockery/mockery": "^1.2",
         "phpunit/phpunit": "^9.0"
     },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "SocialiteProviders\\Manager\\ServiceProvider"
-            ]
-        }
-    },
+    "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
             "SocialiteProviders\\Manager\\": "src/"
@@ -58,9 +53,14 @@
             "SocialiteProviders\\Manager\\Test\\": "tests/"
         }
     },
-    "minimum-stability": "stable",
-    "support": {
-        "issues": "https://github.com/socialiteproviders/manager/issues",
-        "source": "https://github.com/socialiteproviders/manager"
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "SocialiteProviders\\Manager\\ServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
This PR bumps some dependencies

`laravel/socialite:^5.2`
as `$usesPKCE` is already used in a few providers and depends on this version

`phpunit/phpunit:^9.0`
as `^6.0` does not support PHP<8