### PR TITLE
fix: include guzzle configuration when `additionalConfigKeys` is defined in provider

### DIFF
--- a/src/Helpers/ConfigRetriever.php
+++ b/src/Helpers/ConfigRetriever.php
@@ -39,7 +39,9 @@ class ConfigRetriever implements ConfigRetrieverInterface
         $this->providerName = $providerName;
         $this->getConfigFromServicesArray($providerName);
 
-        $this->additionalConfigKeys = $additionalConfigKeys = array_unique($additionalConfigKeys + ['guzzle']);
+        $this->additionalConfigKeys = $additionalConfigKeys = array_unique(
+            array_merge($additionalConfigKeys, ['guzzle']),
+        );
 
         return new Config(
             $this->getFromServices('client_id'),

--- a/tests/ConfigRetrieverTest.php
+++ b/tests/ConfigRetrieverTest.php
@@ -76,6 +76,39 @@ class ConfigRetrieverTest extends TestCase
         $this->assertSame($uri, $result['redirect']);
         $this->assertSame($additionalConfigItem, $result['additional']);
     }
+
+    /**
+     * @test
+     */
+    public function it_retrieves_a_config_from_the_services_with_guzzle(): void
+    {
+        $providerName = 'test';
+        $key = 'key';
+        $secret = 'secret';
+        $uri = 'uri';
+        $additionalConfigItem = 'test';
+        $config = [
+            'client_id' => $key,
+            'client_secret' => $secret,
+            'redirect' => $uri,
+            'additional' => $additionalConfigItem,
+            'guzzle' => ['verify' => false],
+        ];
+        self::$functions
+            ->shouldReceive('config')
+            ->with("services.{$providerName}")
+            ->once()
+            ->andReturn($config);
+        $configRetriever = new ConfigRetriever();
+
+        $result = $configRetriever->fromServices($providerName, ['additional'])->get();
+
+        $this->assertSame($key, $result['client_id']);
+        $this->assertSame($secret, $result['client_secret']);
+        $this->assertSame($uri, $result['redirect']);
+        $this->assertSame($additionalConfigItem, $result['additional']);
+        $this->assertSame(['verify' => false], $result['guzzle']);
+    }
 }
 
 namespace SocialiteProviders\Manager\Helpers;


### PR DESCRIPTION
Fixes https://github.com/SocialiteProviders/Manager/issues/228


## Changes proposed in this pull request:
- use `array_merge` instead of the union operator (+) to include `guzzle` configuration
