### PR TITLE
Use PHP 8.4 as default runner version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         coverage: [ 'none' ]
         php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         exclude:
-          - php-versions: '8.3'
+          - php-versions: '8.4'
         include:
-          - php-versions: '8.3'
+          - php-versions: '8.4'
             coverage: 'xdebug'
 
     name: PHP ${{ matrix.php-versions }}


### PR DESCRIPTION
This PR ensures that PHP 8.4 is used as the default runner