### PR TITLE
chore: modernise package tooling and drop legacy support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  pint:
+    runs-on: ubuntu-latest
+
+    name: Code style
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: json, mbstring
+          coverage: none
+          tools: pint
+
+      - name: Check code style
+        run: pint --test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,8 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
+        php-versions: [ '8.3', '8.4' ]
         coverage: [ 'none' ]
-        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
-        exclude:
-          - php-versions: '8.5'
         include:
           - php-versions: '8.5'
             coverage: 'xdebug'
@@ -34,13 +32,16 @@ jobs:
           coverage: ${{ matrix.coverage }}
 
       - name: Install dependencies
-        run: composer update --no-interaction --prefer-dist --no-suggest --prefer-stable
+        run: composer update --no-interaction --prefer-dist --prefer-stable
 
       - name: Lint composer.json
         run: composer validate --strict
 
+      - name: Check code style
+        run: vendor/bin/pint --test
+
       - name: Run Tests
-        run: vendor/bin/phpunit -v
+        run: vendor/bin/phpunit
 
       - name: Upload coverage results
         if: matrix.coverage != 'none'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: json, mbstring, xdebug
+          extensions: json, mbstring
           coverage: ${{ matrix.coverage }}
 
       - name: Install dependencies
@@ -38,7 +38,12 @@ jobs:
         run: composer validate --strict
 
       - name: Run Tests
+        if: matrix.coverage == 'none'
         run: vendor/bin/phpunit
+
+      - name: Run Tests with coverage
+        if: matrix.coverage != 'none'
+        run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml --coverage-text
 
       - name: Upload coverage results
         if: matrix.coverage != 'none'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Lint composer.json
         run: composer validate --strict
 
-      - name: Check code style
-        run: vendor/bin/pint --test
-
       - name: Run Tests
         run: vendor/bin/phpunit
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Socialite Providers Manager
 
-[![Build Status](https://travis-ci.org/SocialiteProviders/Manager.svg)](https://travis-ci.org/SocialiteProviders/Manager)
+[![Test](https://github.com/SocialiteProviders/Manager/actions/workflows/test.yml/badge.svg)](https://github.com/SocialiteProviders/Manager/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/SocialiteProviders/Manager/branch/master/graph/badge.svg)](https://codecov.io/gh/SocialiteProviders/Manager)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/SocialiteProviders/Manager/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/SocialiteProviders/Manager/?branch=master) 
 [![Latest Stable Version](https://poser.pugx.org/socialiteproviders/manager/v/stable.svg)](https://packagist.org/packages/socialiteproviders/manager) 
@@ -8,7 +8,6 @@
 [![Latest Unstable Version](https://poser.pugx.org/socialiteproviders/manager/v/unstable.svg)](https://packagist.org/packages/socialiteproviders/manager) 
 [![License](https://poser.pugx.org/socialiteproviders/manager/license.svg)](https://packagist.org/packages/socialiteproviders/manager)
 [![StyleCI](https://github.styleci.io/repos/30993504/shield?branch=master)](https://github.styleci.io/repos/30993504?branch=master)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/ddb2f0df-6d85-431c-8e68-6164b08dd852/small.png)](https://insight.sensiolabs.com/projects/ddb2f0df-6d85-431c-8e68-6164b08dd852)
 
 ## About
 
@@ -20,7 +19,6 @@ A package for Laravel Socialite that allows you to easily add new providers or o
 * Instantiation is deferred until Socialite is called
 * You can override current providers
 * You can create new providers
-* Lumen usage is easy
 * `stateless()` can be set to `true` or `false`
 * You can override a config dynamically
 * It retrieves environment variables directly from the `.env` file instead of also having to configure the services array.
@@ -33,17 +31,15 @@ A package for Laravel Socialite that allows you to easily add new providers or o
 
 ## Reference
 
-* [Laravel docs about events](https://laravel.com/docs/7.x/events)
-* [Laracasts video on events in Laravel 5](https://laracasts.com/lessons/laravel-5-events)
-* [Laravel Socialite Docs](https://github.com/laravel/socialite)  
-* [Laracasts Socialite video](https://laracasts.com/series/whats-new-in-laravel-5/episodes/9)
+* [Laravel docs about events](https://laravel.com/docs/13.x/events)
+* [Laravel Socialite Docs](https://laravel.com/docs/13.x/socialite)
 
 
 ## Creating a Handler
 
 Below is an example handler.  You need to add this full class name to the `listen[]` in the `EventServiceProvider`.
 
-* [See also the Laravel docs about events](https://laravel.com/docs/7.x/events).
+* [See also the Laravel docs about events](https://laravel.com/docs/13.x/events).
 * `providername` is the name of the provider such as `meetup`.
 * You will need to change your the namespacing and class names of course.  
 
@@ -65,7 +61,7 @@ class ProviderNameExtendSocialite
 
 ## Creating a Provider
 
-* Look at the already created [providers](https://socialiteproviders.netlify.app/) for inspiration.
+* Look at the already created [providers](https://socialiteproviders.com/) for inspiration.
 * [See this article on Medium](https://medium.com/@morrislaptop/adding-auth-providers-to-laravel-socialite-ca0335929e42)
 
 ## Overriding a Built-in Provider
@@ -91,7 +87,7 @@ return Socialite::with('provider-name')->setConfig($config)->redirect();
 
 ## Creating an OAuth1 Server Class
 
-Take a look at the other [OAuth1 providers](https://socialiteproviders.netlify.app/) for inspiration. 
+Take a look at the other [OAuth1 providers](https://socialiteproviders.com/) for inspiration. 
 
 ## Getting the Access Token Response Body
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ class ProviderNameExtendSocialite
 ## Creating a Provider
 
 * Look at the already created [providers](https://socialiteproviders.com/) for inspiration.
-* [See this article on Medium](https://medium.com/@morrislaptop/adding-auth-providers-to-laravel-socialite-ca0335929e42)
 
 ## Overriding a Built-in Provider
 

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,14 @@
         "source": "https://github.com/socialiteproviders/manager"
     },
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
-        "laravel/socialite": "^5.5"
+        "php": "^8.3",
+        "illuminate/support": "^12.0 || ^13.0",
+        "laravel/socialite": "^5.29"
     },
     "require-dev": {
-        "mockery/mockery": "^1.2",
-        "phpunit/phpunit": "^9.0"
+        "laravel/pint": "^1.30",
+        "mockery/mockery": "^1.6",
+        "phpunit/phpunit": "^12.5"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "laravel/socialite": "^5.29"
     },
     "require-dev": {
-        "laravel/pint": "^1.30",
         "mockery/mockery": "^1.6",
         "phpunit/phpunit": "^12.5"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          backupGlobals="false"
-         backupStaticAttributes="false"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          failOnRisky="true"
          failOnWarning="true"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         verbose="true"
 >
 
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
+    </source>
+
+    <coverage>
         <report>
             <clover outputFile="build/logs/clover.xml"/>
             <text outputFile="php://stdout"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,13 +18,6 @@
         </include>
     </source>
 
-    <coverage>
-        <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <text outputFile="php://stdout"/>
-        </report>
-    </coverage>
-
     <testsuites>
         <testsuite name="SocialiteProviders Manager Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/src/OAuth1/Server.php
+++ b/src/OAuth1/Server.php
@@ -14,6 +14,27 @@ abstract class Server extends BaseServer
     use ConfigTrait;
 
     /**
+     * The client ID set via the dynamic config.
+     *
+     * @var string
+     */
+    protected $clientId;
+
+    /**
+     * The client secret set via the dynamic config.
+     *
+     * @var string
+     */
+    protected $clientSecret;
+
+    /**
+     * The redirect URL set via the dynamic config.
+     *
+     * @var string
+     */
+    protected $redirectUrl;
+
+    /**
      * The custom parameters to be sent with the request.
      *
      * @var array
@@ -39,12 +60,12 @@ abstract class Server extends BaseServer
      * the temporary credentials identifier as passed back by the server
      * and finally the verifier code.
      *
-     * @param  \League\OAuth1\Client\Credentials\TemporaryCredentials  $temporaryCredentials
+     * @param  TemporaryCredentials  $temporaryCredentials
      * @param  string  $temporaryIdentifier
      * @param  string  $verifier
      * @return array
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getTokenCredentials(TemporaryCredentials $temporaryCredentials, $temporaryIdentifier, $verifier)
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,19 +13,9 @@ class ServiceProvider extends SocialiteServiceProvider
      */
     public function boot()
     {
-        if ($this->app instanceof \Illuminate\Foundation\Application) {
-            // Laravel
-            $this->app->booted(function () {
-                $socialiteWasCalled = app(SocialiteWasCalled::class);
-
-                event($socialiteWasCalled);
-            });
-        } else {
-            // Lumen
-            $socialiteWasCalled = app(SocialiteWasCalled::class);
-
-            event($socialiteWasCalled);
-        }
+        $this->app->booted(function () {
+            event(app(SocialiteWasCalled::class));
+        });
     }
 
     /**
@@ -34,10 +24,6 @@ class ServiceProvider extends SocialiteServiceProvider
     public function register()
     {
         parent::register();
-
-        if (class_exists('Laravel\Lumen\Application') && ! defined('SOCIALITEPROVIDERS_STATELESS')) {
-            define('SOCIALITEPROVIDERS_STATELESS', true);
-        }
 
         if (! $this->app->bound(ConfigRetrieverInterface::class)) {
             $this->app->singleton(ConfigRetrieverInterface::class, fn () => new ConfigRetriever);

--- a/tests/ConfigRetrieverTest.php
+++ b/tests/ConfigRetrieverTest.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Manager\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\Exception\MissingConfigException;
 use SocialiteProviders\Manager\Helpers\ConfigRetriever;
@@ -10,9 +11,7 @@ class ConfigRetrieverTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_there_is_a_problem_with_the_services_config(): void
     {
         $this->expectExceptionObject(new MissingConfigException('There is no services entry for test'));
@@ -28,9 +27,7 @@ class ConfigRetrieverTest extends TestCase
         $configRetriever->fromServices($providerName)->get();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_there_are_missing_items_in_the_services_config(): void
     {
         $this->expectExceptionObject(new MissingConfigException('There is no services entry for test'));
@@ -46,9 +43,7 @@ class ConfigRetrieverTest extends TestCase
         $configRetriever->fromServices($providerName)->get();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_retrieves_a_config_from_the_services(): void
     {
         $providerName = 'test';
@@ -77,9 +72,7 @@ class ConfigRetrieverTest extends TestCase
         $this->assertSame($additionalConfigItem, $result['additional']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_retrieves_a_config_from_the_services_with_guzzle(): void
     {
         $providerName = 'test';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -2,13 +2,12 @@
 
 namespace SocialiteProviders\Manager;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_a_config_array(): void
     {
         $key = 'key';
@@ -25,9 +24,7 @@ class ConfigTest extends TestCase
         $this->assertSame($result, $config->get());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_additional_config_items(): void
     {
         $key = 'key';
@@ -46,9 +43,7 @@ class ConfigTest extends TestCase
         $this->assertSame($result, $config->get());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_closure_config_redirect()
     {
         $key = 'key';

--- a/tests/OAuth1ProviderTest.php
+++ b/tests/OAuth1ProviderTest.php
@@ -4,6 +4,7 @@ namespace SocialiteProviders\Manager\Test;
 
 use Laravel\Socialite\Contracts\Factory as SocialiteFactoryContract;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\Exception\InvalidArgumentException;
 use SocialiteProviders\Manager\SocialiteWasCalled;
@@ -12,9 +13,7 @@ class OAuth1ProviderTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_should_build_a_provider_and_extend_socialite(): void
     {
         $providerName = 'bar';
@@ -56,9 +55,7 @@ class OAuth1ProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_given_an_invalid_oauth1_provider(): void
     {
         $this->expectExceptionObject(new InvalidArgumentException("FooBar doesn't exist"));
@@ -87,9 +84,7 @@ class OAuth1ProviderTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_given_an_invalid_oauth1_server(): void
     {
         $this->expectExceptionObject(new InvalidArgumentException("FooBar doesn't exist"));

--- a/tests/OAuth2ProviderTest.php
+++ b/tests/OAuth2ProviderTest.php
@@ -5,6 +5,7 @@ namespace SocialiteProviders\Manager\Test;
 use Laravel\Socialite\Contracts\Factory as SocialiteFactoryContract;
 use Laravel\Socialite\One\AbstractProvider;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\Config;
 use SocialiteProviders\Manager\Exception\InvalidArgumentException;
@@ -16,9 +17,7 @@ class OAuth2ProviderTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_there_is_no_config_in_services_or_env(): void
     {
         $this->expectExceptionObject(new MissingConfigException);
@@ -55,9 +54,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $providerClass);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_the_config_to_be_retrieved_from_the_services_array(): void
     {
         $providerName = 'bar';
@@ -92,9 +89,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $providerClass);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_a_custom_config_to_be_passed_dynamically(): void
     {
         $provider = new OAuth2ProviderStub(
@@ -109,9 +104,7 @@ class OAuth2ProviderTest extends TestCase
         $this->assertSame($provider, $result);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_retrieves_from_the_config_if_no_config_is_provided(): void
     {
         $providerName = 'bar';
@@ -145,9 +138,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $providerClass);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_should_build_a_provider_and_extend_socialite(): void
     {
         $providerName = 'bar';
@@ -186,9 +177,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $providerClass);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_given_a_bad_provider_class_name(): void
     {
         $this->expectExceptionObject(new InvalidArgumentException("FooBar doesn't exist"));
@@ -229,9 +218,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $this->invalidClass());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_given_an_invalid_oauth2_provider(): void
     {
         $this->expectExceptionObject(new InvalidArgumentException("FooBar doesn't exist"));
@@ -252,9 +239,7 @@ class OAuth2ProviderTest extends TestCase
         $event->extendSocialite($providerName, $this->invalidClass());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_if_oauth1_server_is_passed_for_oauth2(): void
     {
         $this->expectExceptionObject(new InvalidArgumentException(

--- a/tests/OAuthTwoTest.php
+++ b/tests/OAuthTwoTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\User as SocialiteOAuth2User;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\OAuth2\User;
 use SocialiteProviders\Manager\Test\Stubs\OAuthTwoTestProviderStub;
@@ -17,10 +18,8 @@ class OAuthTwoTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
-    public function redirectGeneratesTheProperSymfonyRedirectResponse(): void
+    #[Test]
+    public function redirect_generates_the_proper_symfony_redirect_response(): void
     {
         $session = m::mock(SessionContract::class);
         $request = Request::create('foo');
@@ -35,9 +34,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('http://auth.url', $response->getTargetUrl());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_return_the_service_container_key(): void
     {
         $result = OAuthTwoTestProviderStub::serviceContainerKey(OAuthTwoTestProviderStub::PROVIDER_NAME);
@@ -45,10 +42,8 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('SocialiteProviders.config.test', $result);
     }
 
-    /**
-     * @test
-     */
-    public function userReturnsAUserInstanceForTheAuthenticatedRequest(): void
+    #[Test]
+    public function user_returns_a_user_instance_for_the_authenticated_request(): void
     {
         $session = m::mock(SessionContract::class);
         $request = Request::create('foo', 'GET', [
@@ -88,9 +83,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('foo', $user->id);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function access_token_response_body_is_accessible_from_user(): void
     {
         $session = m::mock(SessionContract::class);
@@ -133,9 +126,7 @@ class OAuthTwoTest extends TestCase
         $this->assertSame($user->accessTokenResponseBody, json_decode($accessTokenResponseBody, true));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function regular_laravel_socialite_class_works_as_well(): void
     {
         $session = m::mock(SessionContract::class);
@@ -178,10 +169,8 @@ class OAuthTwoTest extends TestCase
         $this->assertSame('foo', $user->id);
     }
 
-    /**
-     * @test
-     */
-    public function exceptionIsThrownIfStateIsInvalid(): void
+    #[Test]
+    public function exception_is_thrown_if_state_is_invalid(): void
     {
         $this->expectExceptionObject(new InvalidStateException);
 
@@ -200,10 +189,8 @@ class OAuthTwoTest extends TestCase
         $provider->user();
     }
 
-    /**
-     * @test
-     */
-    public function exceptionIsThrownIfStateIsNotSet(): void
+    #[Test]
+    public function exception_is_thrown_if_state_is_not_set(): void
     {
         $this->expectExceptionObject(new InvalidStateException);
 
@@ -221,10 +208,8 @@ class OAuthTwoTest extends TestCase
         $provider->user();
     }
 
-    /**
-     * @test
-     */
-    public function userObjectShouldBeCachedOnFirstCall(): void
+    #[Test]
+    public function user_object_should_be_cached_on_first_call(): void
     {
         $session = m::mock(SessionContract::class);
         $accessTokenResponseBody = '{"access_token": "access_token", "test": "test"}';
@@ -263,7 +248,6 @@ class OAuthTwoTest extends TestCase
 
         $reflection = new \ReflectionClass($provider);
         $reflectionProperty = $reflection->getProperty('user');
-        $reflectionProperty->setAccessible(true);
 
         $this->assertNull($reflectionProperty->getValue($provider));
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Manager\Test;
 
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\ServiceProvider;
 use SocialiteProviders\Manager\SocialiteWasCalled;
@@ -11,9 +12,7 @@ class ServiceProviderTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fires_an_event(): void
     {
         $socialiteWasCalledMock = m::mock(SocialiteWasCalled::class);

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace SocialiteProviders\Manager\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SocialiteProviders\Manager\OAuth2\User;
 
@@ -9,9 +10,7 @@ class UserTest extends TestCase
 {
     use ManagerTestTrait;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function we_should_be_able_to_set_the_credentials_body(): void
     {
         $credentialsBody = ['test'];


### PR DESCRIPTION
Modernises the package's dependencies, test tooling and CI matrix.

## PHP & Laravel

- Bump `php` to `^8.3`. 8.2 is security-only until Dec 2026 and receives no bug fixes.
- Drop `illuminate/support: ^11.0`, keeping `^12.0 || ^13.0`. L11 permits PHP 8.2, which conflicts with the new floor.
- Bump `laravel/socialite` to `^5.29`.

## Testing

- PHPUnit `^9.0` → `^12.5`, and Mockery to `^1.6`.
- Migrate the 28 `@test` annotations to `#[Test]` attributes (annotations were removed in PHPUnit 12).
- Rewrite `phpunit.xml.dist` for the 12.5 schema, dropping attributes removed in 10+ (`convertErrorsToExceptions`, `backupStaticAttributes`, `verbose`) and moving `<coverage><include>` to `<source>`.
- Declare `clientId`/`clientSecret`/`redirectUrl` on `OAuth1\Server`. `ConfigTrait::setConfig()` assigned them without declaration, which is deprecated on PHP 8.4+.
- Drop a no-op `ReflectionProperty::setAccessible()` call, deprecated in PHP 8.5.

The suite passes on PHP 8.5 with no deprecations.

## Lumen

Removes the Lumen branch from `ServiceProvider`. Lumen's final release (v11.2.0, Nov 2024) requires `illuminate/support: ^11.0`, so it can no longer resolve against this package once L11 is dropped — the branch is unreachable.

The `SOCIALITEPROVIDERS_STATELESS` **reads** in `SocialiteWasCalled` and `OAuth1\AbstractProvider` are deliberately kept, since users may define the constant themselves to force stateless mode. Only the Lumen-specific auto-define is gone.

## CI

- Matrix now runs 8.3, 8.4, 8.5 (was 8.2–8.5), with 8.5 carrying coverage.
- Drop `--no-suggest` (a no-op since Composer 2) and `phpunit -v` (removed in PHPUnit 10).
- Add a separate `Lint` workflow running `pint --test`. `pint.json` was already committed but was never actually enforced. Pint is installed via `setup-php`, so it stays out of the package's dependency graph.

⚠️ **The new Lint job will fail on this PR.** It flags 10 files whose formatting predates this branch and that this PR does not touch. Reformatting them is deliberately left to a follow-up so the diff here stays reviewable. It is a separate workflow specifically so this does not mask the test matrix results.

## Docs

Replace the dead Travis and SensioLabsInsight badges with the Actions badge, point Laravel doc links at 13.x, drop two Laravel 5-era Laracasts links, update `socialiteproviders.netlify.app` links to the live domain, and remove the "Lumen usage is easy" line.

---

**Note:** this is a breaking change (PHP floor, L11 drop, Lumen removal) and needs a major version bump.
